### PR TITLE
Indirect access to variables, properties and methods will be evaluate…

### DIFF
--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -880,8 +880,16 @@ class WP_Import extends WP_Importer {
 			$menu_id = is_array( $menu_id ) ? $menu_id['term_id'] : $menu_id;
 		}
 
-		foreach ( $item['postmeta'] as $meta )
+// XTEC ************ MODIFICAT - Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity.
+// 2017.11.23 @nacho
+//************ ORIGINAL
+/*        foreach ( $item['postmeta'] as $meta )
 			$$meta['key'] = $meta['value'];
+*/
+//************ FI
+		foreach ( $item['postmeta'] as $meta ) {
+            ($$meta)['key'] = $meta['value'];
+		}
 
 		if ( 'taxonomy' == $_menu_item_type && isset( $this->processed_terms[intval($_menu_item_object_id)] ) ) {
 			$_menu_item_object_id = $this->processed_terms[intval($_menu_item_object_id)];


### PR DESCRIPTION
Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity.